### PR TITLE
Update manifest for Foundry v13 and pf2e

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CultMaker Module</title>
+  </head>
+  <body>
+    <h1>CultMaker for Foundry VTT</h1>
+    <p>Install this module in Foundry VTT by using the manifest URL below:</p>
+    <pre><code>https://your-github.github.io/cultmaker/module.json</code></pre>
+    <p><a href="module.json">View the manifest file</a></p>
+  </body>
+</html>

--- a/module.json
+++ b/module.json
@@ -3,15 +3,25 @@
   "name": "cultmaker",
   "title": "CultMaker",
   "description": "Cult management system for Pathfinder 2e campaigns inside Foundry VTT.",
-  "version": "0.1.0",
-  "minimumCoreVersion": "11",
-  "compatibleCoreVersion": "11",
+  "version": "0.2.0",
+  "minimumCoreVersion": "13",
+  "compatibleCoreVersion": "13",
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
   "authors": [{ "name": "Christopher Mills" }],
-  "url": "https://github.com/your‑github/cultmaker",
-  "manifest": "https://raw.githubusercontent.com/your‑github/cultmaker/main/module.json",
-  "download": "https://github.com/your‑github/cultmaker/releases/latest/download/cultmaker.zip",
+  "url": "https://github.com/your-github/cultmaker",
+  "manifest": "https://your-github.github.io/cultmaker/module.json",
+  "download": "https://github.com/your-github/cultmaker/releases/latest/download/cultmaker.zip",
   "esmodules": ["dist/cultmaker.js"],
   "styles": ["styles/cultmaker.css"],
+  "systems": ["pf2e"],
+  "relationships": {
+    "systems": {
+      "pf2e": ">=7.3.1"
+    }
+  },
   "packs": [],
   "socket": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultmaker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cult management system for Pathfinder 2e campaigns inside Foundry VTT.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- update module manifest for Foundry V13 and latest PF2e
- add GitHub Pages hosting page for manifest

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ef732cf948332840990b13b21709a